### PR TITLE
fix: export warn function

### DIFF
--- a/lua/origami/utils.lua
+++ b/lua/origami/utils.lua
@@ -6,5 +6,7 @@ local function warn(msg)
 	vim.notify(msg, vim.log.levels.WARN, { title = "nvim-origami", ft = "markdown" })
 end
 
+M.warn = warn
+
 --------------------------------------------------------------------------------
 return M


### PR DESCRIPTION
## What problem does this PR solve?

```lua
require("origami.features.remember-folds")
```
fails with:
```
E5108: Error executing lua ...igami-2025-03-30/lua/origami/features/remember-folds.lua:2: attempt to call field 'warn' (a nil value)
stack traceback:
        ...igami-2025-03-30/lua/origami/features/remember-folds.lua:2: in main chunk
        [C]: in function 'require'
        [string ":lua"]:1: in main chunk
```

## How does the PR solve it?

It exports the `warn` function that is currently inaccessible, as far as my understanding goes.

## Checklist
- [x] Used only `camelCase` variable names.
- [ ] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be
  modified).
