### PR TITLE
fix(foldtext): check diagnostic signs typing table

### DIFF
--- a/lua/origami/features/foldtext.lua
+++ b/lua/origami/features/foldtext.lua
@@ -10,7 +10,7 @@ local config = require("origami.config").config
 local signConfig = vim.diagnostic.config().signs
 local diagIcons = { "E", "W", "I", "H" }
 local diagHls = { "DiagnosticError", "DiagnosticWarn", "DiagnosticInfo", "DiagnosticHint" }
-if signConfig then
+if type(signConfig) == "table" then
 	diagIcons = vim.diagnostic.config().signs.text or diagIcons
 	diagHls = vim.diagnostic.config().signs.linehl or diagHls
 end


### PR DESCRIPTION
Closes #19

vim.diagnostic.config().signs can be `boolean` or `vim.diagnostic.Opts.Signs` table, default is true

## What problem does this PR solve?

## How does the PR solve it?

## Checklist
- [-] Used only `camelCase` variable names.
- [-] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be
  modified).
