### PR TITLE
fix: dont jump on fold-pause/unpause

### DIFF
--- a/lua/origami/features/pause-folds-on-search.lua
+++ b/lua/origami/features/pause-folds-on-search.lua
@@ -27,7 +27,9 @@ vim.on_key(function(char)
 	local pauseFold = (searchConfirmed or searchStarted or searchMovement) and not foldsArePaused
 	local unpauseFold = foldsArePaused and (searchCancelled or not searchMovement)
 	if pauseFold then
+		local topline = vim.api.nvim_win_get_cursor(0)[1] - vim.fn.winline() + 1
 		vim.opt_local.foldenable = false
+		vim.fn.winrestview({ topline = topline }) -- Restore "scroll"
 	elseif unpauseFold then
 		vim.opt_local.foldenable = true
 		pcall(vim.cmd.foldopen, { bang = true }) -- after closing folds, keep the *current* fold open


### PR DESCRIPTION
## What problem does this PR solve?

When starting/ending search folding is paused/unpaused which causes the text to scroll/jump.

## How does the PR solve it?

This restores the top line of the window

## Checklist
- [x] Used only `camelCase` variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be
  modified).
