### PR TITLE
fix: don't unpauseFold on searchConfirmed

### DIFF
--- a/lua/origami/pause-folds-on-search.lua
+++ b/lua/origami/pause-folds-on-search.lua
@@ -23,9 +23,11 @@ vim.on_key(function(char)
 	local foldsArePaused = not (vim.opt.foldenable:get())
 	-- works for RHS, therefore no need to consider remaps
 	local searchMovement = vim.tbl_contains({ "n", "N", "*", "#" }, key)
+	-- searchConfirmed should not cause unpauseFold:
+	local notSearchMovement = not searchMovement and not searchConfirmed
 
 	local pauseFold = (searchConfirmed or searchStarted or searchMovement) and not foldsArePaused
-	local unpauseFold = foldsArePaused and (searchCancelled or not searchMovement)
+	local unpauseFold = foldsArePaused and (searchCancelled or notSearchMovement)
 	if pauseFold then
 		vim.opt_local.foldenable = false
 	elseif unpauseFold then


### PR DESCRIPTION
## What problem does this PR solve?

Confirming your search with `<CR>` doesn't generally mean that you've finished searching,
so we should not unpauseFolds quite yet. Usually I then go to next hit by hitting `n` a few times
yet the fold that was opened upon `<CR>` remains open even though I'm now far past it.

## Checklist
- [x] Used only `camelCase` variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be
  modified).
