### PR TITLE
feat(foldtext): allow function() for virtual text components

### DIFF
--- a/lua/origami/config.lua
+++ b/lua/origami/config.lua
@@ -10,10 +10,13 @@ local defaultConfig = {
 		enabled = true,
 		padding = 3,
 		lineCount = {
+		   ---@type string | fun():string
 			template = "%d lines", -- `%d` is replaced with the number of folded lines
 			hlgroup = "Comment",
 		},
+		---@type boolean | fun():boolean
 		diagnosticsCount = true, -- uses hlgroups and icons from `vim.diagnostic.config().signs`
+		---@type boolean | fun():boolean
 		gitsignsCount = true, -- requires `gitsigns.nvim`
 	},
 	autoFold = {


### PR DESCRIPTION
## What problem does this PR solve?
Virtual text components can only be directed using booleans / strings

## How does the PR solve it?
Functions can be used to toggle or change strings for virtual text components

## Checklist
- [x] Used only `camelCase` variable names.
- [X] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be
  modified).
