### PR TITLE
fix: prevent treesitter query crash for unknown embedded languages

### DIFF
--- a/lua/origami/features/lsp-and-treesitter-foldexpr.lua
+++ b/lua/origami/features/lsp-and-treesitter-foldexpr.lua
@@ -23,7 +23,13 @@ vim.api.nvim_create_autocmd("FileType", {
 		local win = vim.api.nvim_get_current_win()
 		local filetype = ctx.match
 
-		if vim.treesitter.query.get(filetype, "folds") then
+		local hasParser = false
+		-- безопасно обернуть в pcall, чтобы избежать краша
+		local ok, _ = pcall(function()
+			hasParser = vim.treesitter.query.get(filetype, "folds") ~= nil
+		end)
+
+		if ok and hasParser then
 			vim.wo[win][0].foldmethod = "expr"
 			vim.wo[win][0].foldexpr = "v:lua.vim.treesitter.foldexpr()"
 			vim.b.origami_folding_provider = "treesitter"


### PR DESCRIPTION
## What problem does this PR solve?
This PR resolves a runtime error that occurs when interacting with files containing embedded languages that have no available Tree-sitter parser. A common example is Vue Single File Components (.vue), where attempting to comment a line (e.g., using gcc) triggers an error:
`Error executing lua callback: ...treesitter/query.lua:372: No parser for language "ecma"`
The error is caused by an unguarded call to vim.treesitter.query.get(...) in origami, which does not account for cases where Tree-sitter cannot resolve the query due to a missing parser.
## How does the PR solve it?
The PR wraps the call to `vim.treesitter.query.get(filetype, "folds")` in a `pcall()`, ensuring that if the query fails (e.g., due to an unknown or missing parser), `origami` will gracefully fall back to the `"indent"` folding method instead of throwing a Lua error. This protects Neovim from crashing or malfunctioning when dealing with incomplete or composite filetypes such as `.vue`, `.md`, or `.svelte`.
## Checklist
- [x] Used only `camelCase` variable names.
- [ ] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be
  modified).