### PR TITLE
feat: add option to disable foldtext per filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ require("origami").setup {
 		},
 		diagnosticsCount = true, -- uses hlgroups and icons from `vim.diagnostic.config().signs`
 		gitsignsCount = true, -- requires `gitsigns.nvim`
+		disableOnFt = { "snacks_picker_input" }, -- disable foldtext in these filetypes
 	},
 	autoFold = {
 		enabled = true,

--- a/lua/origami/config.lua
+++ b/lua/origami/config.lua
@@ -15,6 +15,7 @@ local defaultConfig = {
 		},
 		diagnosticsCount = true, -- uses hlgroups and icons from `vim.diagnostic.config().signs`
 		gitsignsCount = true, -- requires `gitsigns.nvim`
+		disableOnFt = { "snacks_picker_input" }, ---@type string[]
 	},
 	autoFold = {
 		enabled = true,

--- a/lua/origami/features/foldtext.lua
+++ b/lua/origami/features/foldtext.lua
@@ -146,6 +146,14 @@ end
 
 vim.api.nvim_set_decoration_provider(ns, {
 	on_win = function(_, win, buf, topline, botline)
+		if
+			vim.list_contains(
+				require("origami.config").config.foldtext.disableOnFt,
+				vim.bo[buf].filetype
+			)
+		then
+			return
+		end
 		vim.api.nvim_win_call(win, function()
 			local line = topline
 			while line <= botline do


### PR DESCRIPTION
## Problem statement
Currently, when `foldtext` is enabled, the decoration provider applies to all buffers, regardless of filetypes. [This can cause problems when used with certain special buffers/windows](https://github.com/folke/snacks.nvim/discussions/2318).

## Proposed solution
Add a config option that allows the users to disable foldtext on certain `filetype`s.

In the context of the snacks.nvim discussion, setting `disableOnFt = {"snacks_picker_input"}` solved the problem.

## AI usage disclosure
None

## Checklist
- [x] Variable names follow `camelCase` convention.
- [x] All AI-generated code has been reviewed by a human.
- [x] The `README.md` has been updated for any new or modified functionality
  (the `.txt` file is auto-generated and does not need to be modified).
