### PR TITLE
fix: properly use treesitter parser.lang instead of filetype when querying (#54)

### DIFF
--- a/lua/origami/features/lsp-and-treesitter-foldexpr.lua
+++ b/lua/origami/features/lsp-and-treesitter-foldexpr.lua
@@ -19,7 +19,7 @@ end
 ---@param filetype? string
 local function checkForTreesitterWithFallback(bufnr, filetype)
 	if not bufnr then bufnr = 0 end
-	-- always prioritize treesitter parser over LSP for folding
+	-- always prioritize LSP over treesitter parser for folding
 	if vim.b[bufnr].origami_folding_provider == "lsp" then return end
 	local win = vim.api.nvim_get_current_win()
 	if vim.wo[win].diff then return end -- not in diff mode, see #30

--- a/lua/origami/features/lsp-and-treesitter-foldexpr.lua
+++ b/lua/origami/features/lsp-and-treesitter-foldexpr.lua
@@ -24,10 +24,12 @@ local function checkForTreesitterWithFallback(bufnr, filetype)
 	local win = vim.api.nvim_get_current_win()
 	if vim.wo[win].diff then return end -- not in diff mode, see #30
 
-	if not filetype then filetype = vim.bo[bufnr].filetype end
-	local ok, hasParser = pcall(vim.treesitter.query.get, filetype, "folds")
+	local ok, parser = pcall(vim.treesitter.get_parser, bufnr)
+	local lang = ok and parser and parser:lang()
+	local folds = lang and vim.treesitter.query.get(lang, "folds")
+
 	vim.api.nvim_buf_call(bufnr, function()
-		if ok and hasParser then
+		if folds then
 			vim.wo[win][0].foldmethod = "expr"
 			vim.wo[win][0].foldexpr = "v:lua.vim.treesitter.foldexpr()"
 			vim.b[bufnr].origami_folding_provider = "treesitter"


### PR DESCRIPTION
## Problem statement

When calling `vim.treesitter.query.get`, the first argument should be treesitter's parser.lang and not filetype

## Proposed solution

properly fetch parser.lang before calling query

## AI usage disclosure

none

## Checklist
- [x] Variable names follow `camelCase` convention.
- [x] All AI-generated code has been reviewed by a human.
- [x] The `README.md` doesn't need changes.
